### PR TITLE
Implement a `ocibuild python inspect` command

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,7 @@ linters-settings:
       - '^github\.com/google/go-containerregistry/pkg/v1\.(Layer|Image)$'
       - '^github\.com/datawire/ocibuild/pkg/fsutil\.FileReference$'
       - '^github\.com/datawire/ocibuild/pkg/python/pep440\.ExclusionBehavior$'
+      - '^github\.com/datawire/ocibuild/pkg/python/pyinspect.FileInfo$'
   lll:
     # mimic .editorconfig, plus 20 chars of slop
     line-length: 120

--- a/cmd_layer_wheel.go
+++ b/cmd_layer_wheel.go
@@ -28,6 +28,9 @@ func init() {
 			"ocibuild using the --platform-file flag, pointing it at a YAML file that " +
 			"is as follows:" +
 			"\n\n" +
+			"    # This entire file can be generated with the `ocibuild python inspect`\n" +
+			"    # command.\n" +
+			"\n" +
 			"    # file locations\n" +
 			"    ConsoleShebang: /usr/bin/python3.9\n" +
 			"    GraphicalShebang: /usr/bin/python3.9\n" +
@@ -54,10 +57,6 @@ func init() {
 			"    # version number rather precisely; or rather their\n" +
 			"    # `importlib.util.MAGIC_NUMBER` values must match.\n" +
 			"    PyCompile: ['python3.9', '-m', 'compileall']\n" +
-			"\n" +
-			"LIMITATION: It is 'TODO' to create an 'ocibuild python WHATEVER' command " +
-			"that can inspect an image's Python installation and emit the appropriate " +
-			"YAML description of it.\n" +
 			"\n" +
 			"LIMITATION: While checksums are verified, signatures are not.",
 		Args: cliutil.WrapPositionalArgs(cobra.ExactArgs(1)),

--- a/cmd_python_inspect.go
+++ b/cmd_python_inspect.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/datawire/dlib/dexec"
+	"github.com/datawire/dlib/dlog"
+	"github.com/google/go-containerregistry/pkg/name"
+	ociv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"github.com/datawire/ocibuild/pkg/cliutil"
+	"github.com/datawire/ocibuild/pkg/dockerutil"
+	"github.com/datawire/ocibuild/pkg/fsutil"
+	"github.com/datawire/ocibuild/pkg/python"
+	"github.com/datawire/ocibuild/pkg/python/pyinspect"
+)
+
+func init() {
+	var flags struct {
+		Interpreter string
+		ImageFile   string
+	}
+	cmd := &cobra.Command{
+		Use:   "inspect [flags] >PYTHON_PLATFORM.yml",
+		Short: "Dump information about a Python environment",
+		Args:  cliutil.WrapPositionalArgs(cobra.NoArgs),
+		Long: "Inspect a Python environment, and dump information about it for " +
+			"consumption by `ocibuild python wheel --platform-file=`.  The output " +
+			"also includes some informative fields that are not used by " +
+			"`ocibuild python wheel`." +
+			"\n\n" +
+			"LIMITATION: The --imagefile flag requires interacting with a running " +
+			"Docker.",
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			var image ociv1.Image
+			if flags.ImageFile != "" {
+				var err error
+				image, err = fsutil.OpenImage(flags.ImageFile)
+				if err != nil {
+					return err
+				}
+			}
+
+			sys := pyinspect.FS(pyinspect.NativeFS{})
+			if image != nil {
+				sys = &pyinspect.ImageFS{
+					Image: image,
+				}
+			}
+
+			var plat struct {
+				python.Platform `yaml:",inline"`
+				PyCompile       []string
+			}
+			var err error
+
+			plat.ConsoleShebang, plat.GraphicalShebang, err = pyinspect.Shebangs(sys, flags.Interpreter)
+			if err != nil {
+				return err
+			}
+
+			var dyn *pyinspect.DynamicInfo
+			if image == nil {
+				dyn, err = pyinspect.Dynamic(ctx, plat.ConsoleShebang)
+				if err != nil {
+					return err
+				}
+			} else {
+				if err := dockerutil.WithImage(ctx, "python-inspect",
+					image,
+					func(ctx context.Context, tag name.Tag) error {
+						var err error
+						dyn, err = pyinspect.Dynamic(ctx, "docker", "run",
+							"--rm",
+							"--entrypoint="+plat.ConsoleShebang,
+							tag.String())
+						return err
+					},
+				); err != nil {
+					return err
+				}
+			}
+
+			plat.Scheme = dyn.Scheme
+			plat.VersionInfo = &dyn.VersionInfo
+			plat.MagicNumber, err = base64.StdEncoding.DecodeString(dyn.MagicNumberB64)
+			if err != nil {
+				return err
+			}
+			plat.Tags = dyn.Tags
+
+			dirs := []string{
+				dyn.Scheme.PureLib,
+				dyn.Scheme.PlatLib,
+				dyn.Scheme.Headers,
+				dyn.Scheme.Scripts,
+				dyn.Scheme.Data,
+			}
+			foundOwner := false
+			for _, dir := range dirs {
+				info, err := sys.Stat(dir)
+				if err != nil {
+					continue
+				}
+				plat.UID = info.UID()
+				plat.GID = info.GID()
+				plat.UName = info.UName()
+				plat.GName = info.GName()
+				foundOwner = true
+				break
+			}
+			if !foundOwner {
+				return fmt.Errorf("could not stat any of the scheme directories: %#v", dyn.Scheme)
+			}
+
+			if image == nil {
+				plat.PyCompile = []string{plat.ConsoleShebang, "-m", "compileall"}
+			} else {
+				names := []string{
+					fmt.Sprintf("python%d.%d", dyn.VersionInfo.Major, dyn.VersionInfo.Minor),
+					fmt.Sprintf("python%d", dyn.VersionInfo.Major),
+					"python",
+				}
+				for _, name := range names {
+					name, err := dexec.LookPath(name)
+					if err != nil {
+						continue
+					}
+					dlog.Infof(ctx, "inpsecting host %q...", name)
+					nativeDyn, err := pyinspect.Dynamic(ctx, name)
+					if err != nil {
+						dlog.Infof(ctx, "... err %v", err)
+						continue
+					}
+					if nativeDyn.MagicNumberB64 == dyn.MagicNumberB64 {
+						plat.PyCompile = []string{name, "-m", "compileall"}
+						break
+					}
+					magicForLog, err := base64.StdEncoding.DecodeString(nativeDyn.MagicNumberB64)
+					if err != nil {
+						dlog.Infof(ctx, "... err %v", err)
+						continue
+					}
+					dlog.Infof(ctx, "... importlib.util.MAGIC_NUMBER=%q (sys.version_info=%+v)",
+						magicForLog, nativeDyn.VersionInfo)
+				}
+				if plat.PyCompile == nil {
+					return fmt.Errorf("unable to find a Python installatation on the host system that matches importlib.util.MAGIC_NUMBER=%q (sys.version_info=%+v)", //nolint:lll
+						plat.MagicNumber, plat.VersionInfo)
+				}
+			}
+
+			bs, err := yaml.Marshal(plat)
+			if err != nil {
+				return err
+			}
+			if _, err := os.Stdout.Write(bs); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&flags.Interpreter, "interpreter", "python3",
+		"The Python interpreter to inspect")
+	cmd.Flags().StringVar(&flags.ImageFile, "imagefile", "",
+		"Inspect a Docker image's Python rather than the host's Python")
+
+	argparserPython.AddCommand(cmd)
+}

--- a/pkg/dir/dir.go
+++ b/pkg/dir/dir.go
@@ -102,7 +102,7 @@ func LayerFromDir(
 				break
 			}
 		}
-		if header.Typeflag == tar.TypeLink {
+		if header.Typeflag == tar.TypeSymlink {
 			header.Linkname, err = os.Readlink(filename)
 			if err != nil {
 				return err

--- a/pkg/dockerutil/docker.go
+++ b/pkg/dockerutil/docker.go
@@ -1,0 +1,61 @@
+package dockerutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/datawire/dlib/dexec"
+	"github.com/google/go-containerregistry/pkg/name"
+	ociv1 "github.com/google/go-containerregistry/pkg/v1"
+	ociv1tarball "github.com/google/go-containerregistry/pkg/v1/tarball"
+)
+
+func newTag(repo string) (name.Tag, error) {
+	return name.NewTag(fmt.Sprintf("ocibuild.local/%s:%d.%d",
+		repo, os.Getpid(), time.Now().UnixNano()))
+}
+
+func WithImage(
+	ctx context.Context,
+	imgname string,
+	img ociv1.Image,
+	fn func(context.Context, name.Tag) error,
+) (err error) {
+	maybeSetErr := func(_err error) {
+		if _err != nil && err == nil {
+			err = _err
+		}
+	}
+
+	tag, err := newTag(imgname)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		maybeSetErr(dexec.CommandContext(ctx, "docker", "image", "rm", tag.String()).Run())
+	}()
+	cmd := dexec.CommandContext(ctx, "docker", "image", "load")
+	pipe, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	defer func() {
+		_ = pipe.Close()
+		_ = cmd.Wait()
+	}()
+	if err := ociv1tarball.Write(tag, img, pipe); err != nil {
+		return err
+	}
+	if err := pipe.Close(); err != nil {
+		return err
+	}
+	if err := cmd.Wait(); err != nil {
+		return err
+	}
+	return fn(ctx, tag)
+}

--- a/pkg/python/pep425/tags.go
+++ b/pkg/python/pep425/tags.go
@@ -4,6 +4,7 @@
 package pep425
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -25,8 +26,33 @@ func (t Tag) Decompress() []Tag {
 	return ret
 }
 
+func ParseTag(str string) (Tag, error) {
+	parts := strings.Split(str, "-")
+	if len(parts) != 3 {
+		return Tag{}, fmt.Errorf("pep425.ParseTag: invalid tag: %q", str)
+	}
+	return Tag{
+		Python:   parts[0],
+		ABI:      parts[1],
+		Platform: parts[2],
+	}, nil
+}
+
 func (t Tag) String() string {
 	return t.Python + "-" + t.ABI + "-" + t.Platform
+}
+
+func (t Tag) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+func (t *Tag) UnmarshalText(txt []byte) error {
+	_t, err := ParseTag(string(txt))
+	if err != nil {
+		return err
+	}
+	*t = _t
+	return nil
 }
 
 // Intersect returns whether any tag in tag-list 'a' matches any tag in tag-list 'b'; considering

--- a/pkg/python/pyinspect/fs_image.go
+++ b/pkg/python/pyinspect/fs_image.go
@@ -1,0 +1,163 @@
+package pyinspect
+
+import (
+	"archive/tar"
+	"io/fs"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/datawire/dlib/dexec"
+	ociv1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"github.com/datawire/ocibuild/pkg/squash"
+)
+
+type ImageFS struct {
+	Image ociv1.Image
+
+	initOnce sync.Once
+	initErr  error
+	imgWD    string
+	imgPATH  []string
+	imgFS    fs.FS
+}
+
+var _ FS = (*ImageFS)(nil)
+
+// linuxFilepathSplitList mimics path/filepath.SplitList, but always behaves as if GOOS=linux.
+func linuxFilepathSplitList(path string) []string {
+	if path == "" {
+		return []string{}
+	}
+	return strings.Split(path, ":")
+}
+
+// lookupEnv mimics os.LookupEnv, but always behaves as if GOOS=linux, and operates on a a given
+// list of strings rather than os.Environ().  Also there's no caching or anything like that.
+func lookupEnv(environ []string, key string) (val string, ok bool) {
+	prefix := key + "="
+	for _, keyval := range environ {
+		if strings.HasPrefix(keyval, prefix) {
+			// Mimicking syscall.Getenv() (syscall/env_unix.go), first-match wins.
+			return strings.TrimPrefix(keyval, prefix), true
+		}
+	}
+	return "", false
+}
+
+func (*ImageFS) Split(pathname string) (dir, file string) { return path.Split(pathname) }
+func (*ImageFS) Join(elem ...string) string {
+	return path.Join(elem...)
+}
+
+func (sys *ImageFS) ensureInitialized() error {
+	sys.initOnce.Do(func() {
+		sys.initErr = func() error {
+			sys.imgWD = "/"
+			sys.imgPATH = []string{}
+
+			cfgFile, err := sys.Image.ConfigFile()
+			if err != nil {
+				return err
+			}
+			if cfgFile != nil {
+				if cfgFile.Config.WorkingDir != "" {
+					sys.imgWD = cfgFile.Config.WorkingDir
+					if !strings.HasPrefix(sys.imgWD, "/") {
+						sys.imgWD = "/" + sys.imgWD
+					}
+				}
+				if _path, ok := lookupEnv(cfgFile.Config.Env, "PATH"); ok {
+					sys.imgPATH = linuxFilepathSplitList(_path)
+				}
+			}
+
+			layers, err := sys.Image.Layers()
+			if err != nil {
+				return err
+			}
+			vfs, err := squash.Load(layers, true)
+			if err != nil {
+				return err
+			}
+			sys.imgFS = vfs
+
+			return nil
+		}()
+	})
+	return sys.initErr
+}
+
+func (sys *ImageFS) Stat(name string) (FileInfo, error) {
+	if !path.IsAbs(name) {
+		return nil, &fs.PathError{
+			Op:   "stat",
+			Path: name,
+			Err:  fs.ErrInvalid,
+		}
+	}
+	if err := sys.ensureInitialized(); err != nil {
+		return nil, err
+	}
+	fileinfo, err := fs.Stat(sys.imgFS, name[1:])
+	if err != nil {
+		return nil, err
+	}
+	raw := fileinfo.Sys().(*tar.Header) //nolint:forcetypeassert // if not, this is a bug and it should crash
+	return &fileInfo{
+		FileInfo: fileinfo,
+		uid:      raw.Uid,
+		gid:      raw.Gid,
+		uname:    raw.Uname,
+		gname:    raw.Gname,
+	}, nil
+}
+
+func (sys *ImageFS) checkExecutable(fullfilename string) error {
+	fileinfo, err := sys.Stat(fullfilename)
+	if err != nil {
+		return err
+	}
+	if mode := fileinfo.Mode(); mode.IsDir() || mode&0o111 == 0 {
+		return fs.ErrPermission
+	}
+	return nil
+}
+
+func (sys *ImageFS) LookPath(filename string) (_ string, err error) {
+	defer func() {
+		if err != nil {
+			err = &fs.PathError{
+				Op:   "lookpath",
+				Path: filename,
+				Err:  err,
+			}
+		}
+	}()
+
+	if err := sys.ensureInitialized(); err != nil {
+		return "", err
+	}
+
+	if strings.Contains(filename, "/") {
+		fullfilename := filename
+		if !path.IsAbs(fullfilename) {
+			fullfilename = sys.Join(sys.imgWD, fullfilename)
+		}
+		if err := sys.checkExecutable(fullfilename); err != nil {
+			return "", err
+		}
+		return fullfilename, nil
+	}
+	for _, dir := range sys.imgPATH {
+		fullfilename := sys.Join(dir, filename)
+		if !path.IsAbs(fullfilename) {
+			fullfilename = sys.Join(sys.imgWD, fullfilename)
+		}
+		if err := sys.checkExecutable(fullfilename); err == nil {
+			return fullfilename, nil
+		}
+	}
+	return "", dexec.ErrNotFound
+}

--- a/pkg/python/pyinspect/fs_native.go
+++ b/pkg/python/pyinspect/fs_native.go
@@ -1,0 +1,59 @@
+package pyinspect
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/user"
+	"path/filepath"
+	"syscall"
+
+	"github.com/datawire/dlib/dexec"
+)
+
+type NativeFS struct{}
+
+var _ FS = NativeFS{}
+
+func (NativeFS) Split(path string) (dir, file string) { return filepath.Split(path) }
+func (NativeFS) Join(elem ...string) string           { return filepath.Join(elem...) }
+func (NativeFS) Stat(name string) (FileInfo, error) {
+	if !filepath.IsAbs(name) {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrInvalid}
+	}
+	fileinfo, err := os.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+	raw := fileinfo.Sys().(*syscall.Stat_t) //nolint:forcetypeassert // if not, this is a bug and it should crash
+	usr, err := user.LookupId(fmt.Sprintf("%v", raw.Uid))
+	if err != nil {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: err}
+	}
+	grp, err := user.LookupGroupId(fmt.Sprintf("%v", raw.Gid))
+	if err != nil {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: err}
+	}
+	return &fileInfo{
+		FileInfo: fileinfo,
+		uid:      int(raw.Uid),
+		gid:      int(raw.Gid),
+		uname:    usr.Username,
+		gname:    grp.Name,
+	}, nil
+}
+
+func (NativeFS) LookPath(file string) (string, error) {
+	val, err := dexec.LookPath(file)
+	if err != nil {
+		//nolint:errorlint // We don't want to discard wrappers (except dexec.Error itself).
+		if eerr, ok := err.(*dexec.Error); ok {
+			err = &fs.PathError{
+				Op:   "lookpath",
+				Path: file,
+				Err:  eerr.Err,
+			}
+		}
+	}
+	return val, err
+}

--- a/pkg/python/pyinspect/pyinspect.go
+++ b/pkg/python/pyinspect/pyinspect.go
@@ -1,0 +1,125 @@
+// Package pyinspect determines information about a Python environment.
+package pyinspect
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"github.com/datawire/dlib/dexec"
+
+	"github.com/datawire/ocibuild/pkg/python"
+	"github.com/datawire/ocibuild/pkg/python/pep425"
+)
+
+type FileInfo interface {
+	fs.FileInfo
+	UID() int
+	GID() int
+	UName() string
+	GName() string
+}
+
+type fileInfo struct {
+	fs.FileInfo
+	uid, gid     int
+	uname, gname string
+}
+
+func (fi *fileInfo) UID() int      { return fi.uid }
+func (fi *fileInfo) GID() int      { return fi.gid }
+func (fi *fileInfo) UName() string { return fi.uname }
+func (fi *fileInfo) GName() string { return fi.gname }
+
+type FS interface {
+	// Split mimics path/filepath.Split.
+	Split(path string) (dir, file string)
+
+	// Join mimics path/filepath.Join.
+	Join(elem ...string) string
+
+	// Stat mimics os.Stat, but
+	//
+	//  1. with the additional requirement that name must be an absolute path
+	//  2. the FileInfo also exposes ownership information.
+	Stat(name string) (FileInfo, error)
+
+	// LookPath mimics os/exec.LookPath, but io/fs.PathError is used instead of exec.Error.
+	LookPath(file string) (string, error)
+}
+
+// Shebangs takes an interpreter command (like "python3") and turns it in to a pair of paths to put
+// after the "#!" in a shebang.
+func Shebangs(sys FS, generic string) (console, graphical string, err error) {
+	generic, err = sys.LookPath(generic)
+	if err != nil {
+		return "", "", err
+	}
+
+	console = generic
+	if dirPart, filePart := sys.Split(console); strings.HasPrefix(filePart, "pythonw") {
+		withoutW := sys.Join(dirPart, "python"+strings.TrimPrefix(filePart, "pythonw"))
+		if withoutW, err := sys.LookPath(withoutW); err == nil {
+			console = withoutW
+		}
+	}
+
+	graphical = generic
+	if dirPart, filePart := sys.Split(console); strings.HasPrefix(filePart, "python") &&
+		!strings.HasPrefix(filePart, "pythonw") {
+		withW := sys.Join(dirPart, "pythonw"+strings.TrimPrefix(filePart, "python"))
+		if withW, err := sys.LookPath(withW); err == nil {
+			graphical = withW
+		}
+	}
+
+	return console, graphical, nil
+}
+
+type DynamicInfo struct {
+	MagicNumberB64 string
+	Tags           pep425.Installer
+	VersionInfo    python.VersionInfo
+	Scheme         python.Scheme
+}
+
+func Dynamic(ctx context.Context, cmdline ...string) (*DynamicInfo, error) {
+	cmd := dexec.CommandContext(ctx, cmdline[0], append(cmdline[1:], "-c", `
+import json
+import sys
+from base64 import b64encode
+from importlib.util import MAGIC_NUMBER
+from packaging.tags import sys_tags
+from pip._internal.locations import get_scheme
+
+version_info_slots = ['major', 'minor', 'micro', 'releaselevel', 'serial']
+
+scheme=get_scheme("")
+
+json.dump({
+  "MagicNumberB64": b64encode(MAGIC_NUMBER).decode('utf-8'),
+  "Tags": [str(tag) for tag in sys_tags()],
+  "VersionInfo": {slot: getattr(sys.version_info, slot) for slot in version_info_slots},
+  "Scheme": {slot: getattr(scheme, slot) for slot in scheme.__slots__},
+}, sys.stdout)
+`)...)
+	cmd.DisableLogging = true
+	bs, err := cmd.Output()
+	if err != nil {
+		var exitErr *dexec.ExitError
+		if errors.As(err, &exitErr) {
+			err = fmt.Errorf("%w:\n > %s", err,
+				strings.Join(strings.Split(string(exitErr.Stderr), "\n"), "\n > "))
+		}
+		err = fmt.Errorf("running Python: %w", err)
+		return nil, err
+	}
+	var data DynamicInfo
+	if err := json.Unmarshal(bs, &data); err != nil {
+		return nil, err
+	}
+	return &data, nil
+}

--- a/pkg/python/pypa/pip_test.go
+++ b/pkg/python/pypa/pip_test.go
@@ -149,6 +149,10 @@ print(json.dumps({slot: getattr(scheme, slot) for slot in scheme.__slots__}))
 		UName:            usr.Username,
 		GName:            grp.Name,
 		PyCompile:        compiler,
+
+		VersionInfo: nil,
+		MagicNumber: nil,
+		Tags:        nil,
 	}, nil
 }
 

--- a/pkg/squash/readlayer.go
+++ b/pkg/squash/readlayer.go
@@ -24,7 +24,7 @@ type layerFS struct {
 // parseLayer parses a Layer in to a filesystem object, with the following sanitizations made for
 // consistent querying:
 //
-//  - Paths always path.Clean()'d (notably, directories do NOT contain trailing "/").
+//  - Paths are always path.Clean()'d (notably, directories do NOT contain trailing "/").
 func parseLayer(layer ociv1.Layer) (*layerFS, error) {
 	lfs := new(layerFS)
 	layerReader, err := layer.Uncompressed()

--- a/pkg/squash/squash.go
+++ b/pkg/squash/squash.go
@@ -7,6 +7,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"io"
+	"io/fs"
 
 	ociv1 "github.com/google/go-containerregistry/pkg/v1"
 	ociv1tarball "github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -73,4 +74,13 @@ func Squash(layers []ociv1.Layer, opts ...ociv1tarball.LayerOption) (ociv1.Layer
 	return ociv1tarball.LayerFromOpener(func() (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(byteSlice)), nil
 	}, opts...)
+}
+
+// Load multiple layers as a filesystem.
+func Load(layers []ociv1.Layer, omitContent bool) (fs.FS, error) {
+	root, err := loadLayers(layers, omitContent)
+	if err != nil {
+		return nil, err
+	}
+	return root, nil
 }

--- a/pkg/squash/squash.go
+++ b/pkg/squash/squash.go
@@ -10,13 +10,13 @@ import (
 	ociv1tarball "github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
-func loadLayers(layers []ociv1.Layer) (*fsfile, error) {
+func loadLayers(layers []ociv1.Layer, omitContent bool) (*fsfile, error) {
 	root := &fsfile{ //nolint:exhaustivestruct
 		name: ".",
 	}
 	// Apply all the layers
 	for _, layer := range layers {
-		layerFS, err := parseLayer(layer)
+		layerFS, err := parseLayer(layer, omitContent)
 		if err != nil {
 			return nil, err
 		}
@@ -38,7 +38,7 @@ func loadLayers(layers []ociv1.Layer) (*fsfile, error) {
 //  2. Squash properly implements "opaque whiteouts", which go-containerregistry doesn't support.
 func Squash(layers []ociv1.Layer, opts ...ociv1tarball.LayerOption) (ociv1.Layer, error) {
 	// Load the layers.
-	root, err := loadLayers(layers)
+	root, err := loadLayers(layers, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/squash/squash_test.go
+++ b/pkg/squash/squash_test.go
@@ -275,6 +275,27 @@ func TestSquash(t *testing.T) {
 				{Name: "tgtdir/file", Type: tar.TypeReg},
 			},
 		},
+		"overwrite-links": {
+			Input: []TestLayer{
+				{
+					{Name: "bin", Type: tar.TypeDir},
+					{Name: "bin/busybox", Type: tar.TypeReg},
+					{Name: "bin/wget", Type: tar.TypeSymlink, Linkname: "busybox"},
+				},
+				{
+					{Name: "bin/busybox", Type: tar.TypeChar},
+					{Name: "bin/wget", Type: tar.TypeSymlink, Linkname: "busybox"},
+				},
+				{
+					{Name: "bin/busybox", Type: tar.TypeBlock},
+				},
+			},
+			Output: TestLayer{
+				{Name: "bin/", Type: tar.TypeDir},
+				{Name: "bin/busybox", Type: tar.TypeBlock},
+				{Name: "bin/wget", Type: tar.TypeSymlink, Linkname: "busybox"},
+			},
+		},
 	}
 
 	for tcName, tc := range testcases {

--- a/pkg/squash/vfs.go
+++ b/pkg/squash/vfs.go
@@ -8,10 +8,11 @@ import (
 )
 
 type fsfile struct {
-	name     string
+	name     string // basename
 	parent   *fsfile
 	children map[string]*fsfile
 
+	// if header is nil, that implies that this is a directory
 	header *tar.Header
 	body   []byte
 }

--- a/pkg/squash/vfs.go
+++ b/pkg/squash/vfs.go
@@ -1,3 +1,6 @@
+// vfs.go implements a virtual filesystem layer that we extract layer contents in to, in order to
+// squash layers together without needing to hit a real filesystem.
+
 package squash
 
 import (

--- a/pkg/squash/vfs_fs.go
+++ b/pkg/squash/vfs_fs.go
@@ -1,0 +1,229 @@
+// vfs_fs.go is an adapter for the virtual filesystem in vfs.go that adapts it to implement the
+// (read-only) stdlib io/fs.FS interface.
+
+package squash
+
+import (
+	"archive/tar"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+// These are the interfaces that we're implementing.
+var (
+	_ fs.FS          = (*fsfile)(nil)       // from vfs.go; essentially an inode
+	_ fs.File        = (*fsfileReader)(nil) // an open file handle
+	_ fs.ReadDirFile = (*fsfileReader)(nil)
+)
+
+var (
+	ErrIsDir   = syscall.EISDIR
+	ErrMissing = errors.New("not in layers")
+)
+
+// Open implements io/fs.FS.
+func (f *fsfile) Open(name string) (_ fs.File, err error) {
+	defer func() {
+		if err != nil {
+			err = &fs.PathError{
+				Op:   "open",
+				Path: name,
+				Err:  err,
+			}
+		}
+	}()
+	if !fs.ValidPath(name) {
+		return nil, fs.ErrInvalid
+	}
+	lnk, err := fsGet(f, name, false, false)
+	if err != nil {
+		return nil, err
+	}
+	tgt, err := lnk.Get(".", false, true)
+	if err != nil {
+		return nil, err
+	}
+	return &fsfileReader{ //nolint:exhaustivestruct
+		origName: name,
+		tgt:      tgt,
+		lnk:      lnk,
+	}, nil
+}
+
+type fsfileReader struct {
+	// static info
+	origName string  // filename for use in error messages
+	tgt      *fsfile // file info (follow symlinks)
+	lnk      *fsfile // file info (don't follow symlinks)
+
+	// dynamic state
+	mu      sync.Mutex
+	pos     int
+	closed  bool
+	dirents []fs.DirEntry // cache; generated from .tgt.children
+}
+
+// Stat implements io/fs.File.
+func (f *fsfileReader) Stat() (fs.FileInfo, error) {
+	if f.tgt.header == nil {
+		return nil, &fs.PathError{
+			Op:   "stat",
+			Path: f.origName,
+			Err:  ErrMissing,
+		}
+	}
+	hdr := *f.tgt.header // shallow copy
+	hdr.Name = f.lnk.header.Name
+	return hdr.FileInfo(), nil
+}
+
+// Read implements io/fs.File.
+func (f *fsfileReader) Read(buf []byte) (_ int, err error) {
+	defer func() {
+		if err != nil && !errors.Is(err, io.EOF) {
+			err = &fs.PathError{
+				Op:   "read",
+				Path: f.origName,
+				Err:  err,
+			}
+		}
+	}()
+	if f.tgt.header == nil || f.tgt.header.Typeflag == tar.TypeDir {
+		return 0, ErrIsDir
+	}
+	if int64(len(f.tgt.body)) < f.tgt.header.Size {
+		return 0, ErrMissing
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.closed {
+		return 0, fs.ErrClosed
+	}
+	if f.pos == len(f.tgt.body) {
+		return 0, io.EOF
+	}
+	n := copy(buf, f.tgt.body[f.pos:])
+	f.pos += n
+	return n, nil
+}
+
+// Close implements io/fs.File.
+func (f *fsfileReader) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return fs.ErrClosed
+	}
+	f.closed = true
+	return nil
+}
+
+// missingDirEntry is an fs.DirEntry implementation for directories that are missing their
+// `fsfile.header`.
+type missingDirEntry string
+
+func (name missingDirEntry) Name() string          { return string(name) }
+func (missingDirEntry) IsDir() bool                { return true }
+func (missingDirEntry) Type() fs.FileMode          { return fs.ModeDir }
+func (missingDirEntry) Info() (fs.FileInfo, error) { return nil, ErrMissing }
+
+func (name missingDirEntry) String() string { return fmt.Sprintf("<missingDirEntry %q>", string(name)) }
+
+// dirEntry is an fs.DirEntry implementation for direcories that have their `fsfile.header`.
+type dirEntry struct {
+	tgt fs.DirEntry // file info (follow symlinks)
+	lnk fs.DirEntry // file info (don't follow symlinks)
+
+	// If you're thinking "hey, wait a minute, `.tgt` is never used, why do we need it at all?",
+	// the answer is that because the correct behavior of io/fs.FS isn't clear about how to
+	// behave with symlinks there are other reasonable interpretations that would require
+	// `.tgt`, and so I'm leaving it in until we get a clear answer.  Notably, if I wanted to
+	// get the failing testing/fstest.TestFS tests (see vfs_test.go) to pass, we'd need to make
+	// use of `.tgt`, but fixing those would cause other TestFS tests to fail; no way to get
+	// them all to pass righ now if there are symlinks to directories.
+	//
+	// https://github.com/golang/go/issues/45470
+	// https://github.com/golang/go/issues/50401
+}
+
+func (d *dirEntry) Name() string               { return d.lnk.Name() }
+func (d *dirEntry) IsDir() bool                { return d.lnk.IsDir() }
+func (d *dirEntry) Type() fs.FileMode          { return d.lnk.Type() }
+func (d *dirEntry) Info() (fs.FileInfo, error) { return d.lnk.Info() }
+
+func (d *dirEntry) String() string { return fmt.Sprintf("squash.dirEntry{%q}", d.Name()) }
+
+// ReadDir implements io/fs.ReadDirFile.
+func (f *fsfileReader) ReadDir(n int) ([]fs.DirEntry, error) { //nolint:varnamelen // obvious
+	if f.tgt.header != nil && f.tgt.header.Typeflag != tar.TypeDir {
+		return nil, ErrNotDir
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return nil, fs.ErrClosed
+	}
+	if f.dirents == nil {
+		f.dirents = make([]fs.DirEntry, 0, len(f.tgt.children))
+		for childname, lnk := range f.tgt.children {
+			if strings.HasPrefix(childname, ".wh.") {
+				continue
+			}
+
+			var lnkDirEnt fs.DirEntry
+			if lnk.header != nil {
+				lnkDirEnt = fs.FileInfoToDirEntry(lnk.header.FileInfo())
+			} else {
+				lnkDirEnt = missingDirEntry(childname)
+			}
+
+			tgt, err := lnk.Get(".", false, true) // follow symlinks
+			if err != nil {
+				return nil, err
+			}
+			var tgtDirEnt fs.DirEntry
+			if tgt.header != nil {
+				tgtDirEnt = fs.FileInfoToDirEntry(tgt.header.FileInfo())
+			} else {
+				tgtDirEnt = missingDirEntry(childname)
+			}
+
+			f.dirents = append(f.dirents, &dirEntry{
+				lnk: lnkDirEnt,
+				tgt: tgtDirEnt,
+			})
+		}
+		sort.Slice(f.dirents, func(i, j int) bool {
+			return f.dirents[i].Name() < f.dirents[j].Name()
+		})
+	}
+	if f.pos > len(f.dirents) {
+		f.pos = len(f.dirents)
+	}
+	ret := f.dirents[f.pos:]
+	if n > 0 {
+		if n < len(ret) {
+			ret = ret[:n]
+		}
+		if len(ret) == 0 {
+			return nil, io.EOF
+		}
+	}
+	if len(ret) == 0 {
+		ret = nil
+	}
+	f.pos += len(ret)
+	return ret, nil
+}
+
+func (f *fsfileReader) String() string {
+	return fmt.Sprintf("<fsfileReader %p %q : pos=%d>", f, f.origName, f.pos)
+}

--- a/pkg/squash/vfs_test.go
+++ b/pkg/squash/vfs_test.go
@@ -1,0 +1,77 @@
+package squash_test
+
+import (
+	"archive/tar"
+	"errors"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	ociv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/stretchr/testify/require"
+
+	"github.com/datawire/ocibuild/pkg/squash"
+)
+
+func TestVFS(t *testing.T) {
+	t.Parallel()
+	testcases := map[string]TestLayer{
+		"1": {
+			{Name: ".", Type: tar.TypeDir},
+			{Name: "foo", Type: tar.TypeDir},
+			{Name: "foo/.aaa", Type: tar.TypeReg},
+			{Name: "foo/bar", Type: tar.TypeReg},
+			{Name: "foo/baz", Type: tar.TypeReg},
+			{Name: "foo/d", Type: tar.TypeReg},
+			{Name: "foo/moved", Type: tar.TypeReg},
+			{Name: "foo/zap", Type: tar.TypeReg},
+			{Name: "sym", Type: tar.TypeSymlink, Linkname: "foo"},
+		},
+	}
+	for tcName, tc := range testcases {
+		tc := tc
+		t.Run(tcName, func(t *testing.T) {
+			t.Parallel()
+			filenames := make([]string, 0, len(tc)-1)
+			for _, file := range tc {
+				name := path.Clean(file.Name)
+				if name == "." {
+					continue
+				}
+				filenames = append(filenames, name)
+			}
+			layer := tc.ToLayer(t)
+
+			vfs, err := squash.Load([]ociv1.Layer{layer}, false)
+			require.NoError(t, err)
+
+			err = fstest.TestFS(vfs, filenames...)
+			// Filter out some errors https://github.com/golang/go/issues/50401
+			if err != nil {
+				ignoreRE := regexp.MustCompile(`^(.+): Open\+ReadAll: read (.+): is a directory$`)
+				var lines []string
+				for _, line := range strings.Split(err.Error(), "\n") {
+					ignore := false
+					if m := ignoreRE.FindStringSubmatch(line); m != nil {
+						for _, tfile := range tc {
+							if path.Clean(tfile.Name) == path.Clean(m[2]) {
+								ignore = true
+							}
+						}
+					}
+					if !ignore {
+						lines = append(lines, line)
+					}
+				}
+				if len(lines) <= 1 {
+					err = nil
+				} else {
+					err = errors.New(strings.Join(lines, "\n"))
+				}
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/userdocs/ocibuild_layer_wheel.md
+++ b/userdocs/ocibuild_layer_wheel.md
@@ -8,6 +8,9 @@ Given a Python wheel file, transform it in to a layer.
 
 In order to transform the wheel in to a layer, ocibuild needs to know a few things about the target environment.  You must supply this to ocibuild using the --platform-file flag, pointing it at a YAML file that is as follows:
 
+    # This entire file can be generated with the `ocibuild python inspect`
+    # command.
+
     # file locations
     ConsoleShebang: /usr/bin/python3.9
     GraphicalShebang: /usr/bin/python3.9
@@ -34,8 +37,6 @@ In order to transform the wheel in to a layer, ocibuild needs to know a few thin
     # version number rather precisely; or rather their
     # `importlib.util.MAGIC_NUMBER` values must match.
     PyCompile: ['python3.9', '-m', 'compileall']
-
-LIMITATION: It is 'TODO' to create an 'ocibuild python WHATEVER' command that can inspect an image's Python installation and emit the appropriate YAML description of it.
 
 LIMITATION: While checksums are verified, signatures are not.
 

--- a/userdocs/ocibuild_python.md
+++ b/userdocs/ocibuild_python.md
@@ -16,4 +16,5 @@ ocibuild python {[flags]|SUBCOMMAND...}
 
 * [ocibuild](ocibuild.md)	 - Manipulate OCI/Docker images and layers as regular files
 * [ocibuild python getwheel](ocibuild_python_getwheel.md)	 - Download a wheel file from the Python Package Index
+* [ocibuild python inspect](ocibuild_python_inspect.md)	 - Dump information about a Python environment
 

--- a/userdocs/ocibuild_python_inspect.md
+++ b/userdocs/ocibuild_python_inspect.md
@@ -1,0 +1,26 @@
+## ocibuild python inspect
+
+Dump information about a Python environment
+
+### Synopsis
+
+Inspect a Python environment, and dump information about it for consumption by `ocibuild python wheel --platform-file=`.  The output also includes some informative fields that are not used by `ocibuild python wheel`.
+
+LIMITATION: The --imagefile flag requires interacting with a running Docker.
+
+```
+ocibuild python inspect [flags] >PYTHON_PLATFORM.yml
+```
+
+### Options
+
+```
+  -h, --help                 help for inspect
+      --imagefile string     Inspect a Docker image's Python rather than the host's Python
+      --interpreter string   The Python interpreter to inspect (default "python3")
+```
+
+### SEE ALSO
+
+* [ocibuild python](ocibuild_python.md)	 - Interact with Python without the target environment
+


### PR DESCRIPTION
The `ocibuild layer wheel` command requires a YAML file that describes the Python install that it's targeting.  This PR introduces a `ocibuild python inspect` command that inspects a Python install either on the host system or in an image and spits out a YAML file describing it; so that a human doesn't need to write the YAML file by hand.  The documentation for the command (either in the `cmd_*.go` files, or in `./userdocs/`) go in to more detail.

Most of the commits in this PR are actually improving `pkg/squash` to be up to the task of inspecting an existing image.