### PR TITLE
layer gobuild: Implemented an --output flag to avoid timestamp bumps

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -24,6 +24,7 @@ jobs:
           pip3 --version
       - run: make check
       - name: Report test coverage to coveralls.io
+        if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/master' }}
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/cmd_layer_gobuild.go
+++ b/cmd_layer_gobuild.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"errors"
+	"io"
 	"os"
 
+	"github.com/datawire/dlib/dlog"
 	"github.com/spf13/cobra"
 
 	"github.com/datawire/ocibuild/pkg/cliutil"
@@ -12,24 +15,74 @@ import (
 )
 
 func init() {
+	var outputFilename string
 	cmd := &cobra.Command{
 		Use:   "gobuild [flags] PACKAGES... >OUT_LAYERFILE",
 		Short: "Create a layer of Go binaries",
 		Long: "Works more or less like `go build`.  Passes through env-vars (except for " +
 			"GOOS and GOARCH; naturally those need to be set to reflect the target " +
-			"layer).  Use GOFLAGS to pass in extra flags.",
+			"layer).  Use GOFLAGS to pass in extra flags." +
+			"\n\n" +
+			"When directing stdout to a file, the timestamps within the resulting " +
+			"layer file will be the current time (clamped by SOURCE_DATE_EPOCH).  " +
+			"If SOURCE_DATE_EPOCH is not set, this may result in unnecessary layer " +
+			"changes; to prevent this, use the --output=FILENAME flag, which avoids " +
+			"updating the layer file if the only changes are timestamps.",
 		Args: cliutil.WrapPositionalArgs(cobra.MinimumNArgs(1)),
-		RunE: func(flags *cobra.Command, args []string) error {
+		RunE: func(flags *cobra.Command, args []string) (err error) {
+			maybeSetErr := func(_err error) {
+				if _err != nil && err == nil {
+					err = _err
+				}
+			}
+
 			layer, err := gobuild.LayerFromGo(flags.Context(), reproducible.Now(), args)
 			if err != nil {
 				return err
 			}
 
-			if err := fsutil.WriteLayer(layer, os.Stdout); err != nil {
+			outputWriter := io.Writer(os.Stdout)
+			if outputFilename != "" {
+				// Check if the layer changed.
+				if oldLayer, err := fsutil.OpenLayer(outputFilename); err != nil {
+					if !errors.Is(err, os.ErrNotExist) {
+						return err
+					}
+				} else {
+					equal, err := fsutil.LayersEqualExceptTimestamps(layer, oldLayer)
+					if err != nil {
+						return err
+					}
+					if equal {
+						dlog.Infoln(flags.Context(), "Layer didn't change")
+						return nil
+					}
+				}
+
+				// Open the file for writing.
+				if err := os.Remove(outputFilename); err != nil && !errors.Is(err, os.ErrNotExist) {
+					return err
+				}
+				outputFile, err := os.OpenFile(outputFilename, os.O_CREATE|os.O_WRONLY, 0o666)
+				if err != nil {
+					return err
+				}
+				defer func() {
+					maybeSetErr(outputFile.Close())
+				}()
+				outputWriter = outputFile
+			}
+
+			if err := fsutil.WriteLayer(layer, outputWriter); err != nil {
 				return err
 			}
+
 			return nil
 		},
 	}
+	cmd.Flags().StringVarP(&outputFilename, "output", "o", "", ""+
+		"Write the layer to `FILENAME`, rather than stdout.  "+
+		"Using this rather than directing stdout to a file may prevent unnescessary timestamp bumps.")
+
 	argparserLayer.AddCommand(cmd)
 }

--- a/pkg/fsutil/diff.go
+++ b/pkg/fsutil/diff.go
@@ -1,0 +1,102 @@
+package fsutil
+
+import (
+	"archive/tar"
+	"bytes"
+	"errors"
+	"io"
+	"reflect"
+
+	ociv1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func readersEqual(a, b io.Reader) (equal bool, err error) {
+	const chunkSize = 1024
+
+	var aBuf, bBuf [chunkSize]byte
+	for {
+		aLen, err := io.ReadFull(a, aBuf[:])
+		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			return false, err
+		}
+		bLen, err := io.ReadFull(b, bBuf[:])
+		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			return false, err
+		}
+		if !bytes.Equal(aBuf[:aLen], bBuf[:bLen]) {
+			return false, nil
+		}
+		if aLen < chunkSize {
+			// EOF
+			break
+		}
+	}
+
+	return true, nil
+}
+
+func headersEqualExceptTimestamps(a, b tar.Header) bool {
+	b.ModTime = a.ModTime
+	b.AccessTime = a.AccessTime
+	b.ModTime = a.ModTime
+
+	return reflect.DeepEqual(a, b)
+}
+
+func LayersEqualExceptTimestamps(aLayer, bLayer ociv1.Layer) (equal bool, err error) {
+	maybeSetErr := func(_err error) {
+		if _err != nil && err == nil {
+			equal = false
+			err = _err
+		}
+	}
+
+	aIOReader, err := aLayer.Uncompressed()
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		maybeSetErr(aIOReader.Close())
+	}()
+	aTarReader := tar.NewReader(aIOReader)
+
+	bIOReader, err := bLayer.Uncompressed()
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		maybeSetErr(bIOReader.Close())
+	}()
+	bTarReader := tar.NewReader(bIOReader)
+
+	for {
+		aHeader, err := aTarReader.Next()
+		if err != nil && !errors.Is(err, io.EOF) {
+			return false, err
+		}
+		bHeader, err := bTarReader.Next()
+		if err != nil && !errors.Is(err, io.EOF) {
+			return false, err
+		}
+		if aHeader == nil && bHeader == nil {
+			// got EOF from both
+			break
+		}
+		if aHeader == nil || bHeader == nil {
+			// one got EOF before the other
+			return false, nil
+		}
+
+		if !headersEqualExceptTimestamps(*aHeader, *bHeader) {
+			return false, nil
+		}
+
+		if equal, err := readersEqual(aTarReader, bTarReader); err != nil {
+			return false, err
+		} else if !equal {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/testutil/diff.go
+++ b/pkg/testutil/diff.go
@@ -35,8 +35,8 @@ func DumpLayerFull(layer ociv1.Layer) (str string, err error) {
 
 	ret := new(strings.Builder)
 
-	layerReader, _err := layer.Uncompressed()
-	if _err != nil {
+	layerReader, err := layer.Uncompressed()
+	if err != nil {
 		return "", err
 	}
 	defer func() {
@@ -90,8 +90,8 @@ func DumpLayerListing(layer ociv1.Layer) (str string, err error) {
 
 	ret := new(strings.Builder)
 
-	layerReader, _err := layer.Uncompressed()
-	if _err != nil {
+	layerReader, err := layer.Uncompressed()
+	if err != nil {
 		return "", err
 	}
 	defer func() {

--- a/userdocs/ocibuild_layer_gobuild.md
+++ b/userdocs/ocibuild_layer_gobuild.md
@@ -6,6 +6,8 @@ Create a layer of Go binaries
 
 Works more or less like `go build`.  Passes through env-vars (except for GOOS and GOARCH; naturally those need to be set to reflect the target layer).  Use GOFLAGS to pass in extra flags.
 
+When directing stdout to a file, the timestamps within the resulting layer file will be the current time (clamped by SOURCE_DATE_EPOCH).  If SOURCE_DATE_EPOCH is not set, this may result in unnecessary layer changes; to prevent this, use the --output=FILENAME flag, which avoids updating the layer file if the only changes are timestamps.
+
 ```
 ocibuild layer gobuild [flags] PACKAGES... >OUT_LAYERFILE
 ```
@@ -13,7 +15,8 @@ ocibuild layer gobuild [flags] PACKAGES... >OUT_LAYERFILE
 ### Options
 
 ```
-  -h, --help   help for gobuild
+  -h, --help              help for gobuild
+  -o, --output FILENAME   Write the layer to FILENAME, rather than stdout.  Using this rather than directing stdout to a file may prevent unnescessary timestamp bumps.
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
I'd write something here, but I'd just be duplicating the discussion from the `ocibuild layer gobuild --help` text; go read that in the patch.

As usual, I suggest a commit-by-commit review.

I didn't add any tests, shame on me.